### PR TITLE
chore(test): 🔧 🚨 increase JS memory allocation limit

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-options=--max_old_space_size=4096


### PR DESCRIPTION
Without this fix tests fail on Node v11