### PR TITLE
fix(karma): Always initilize reporter adapters

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -28,7 +28,6 @@ export const sabarivkaReporter: KarmaReporter = Object.defineProperty(
     this.adapters = [];
     if (!isKarmaConfigAppropriate(karmaConfig, logger)) {
       return;
-
     }
     this.onBrowserComplete = getFileInstrumenterFn(karmaConfig);
   },

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -25,12 +25,12 @@ export const sabarivkaReporter: KarmaReporter = Object.defineProperty(
     karmaConfig: KarmaOptions,
     logger: Logger
   ): void {
+    this.adapters = [];
     if (!isKarmaConfigAppropriate(karmaConfig, logger)) {
       return;
-    }
 
+    }
     this.onBrowserComplete = getFileInstrumenterFn(karmaConfig);
-    this.adapters = [];
   },
   '$inject',
   {


### PR DESCRIPTION
Intelij's plugin is using karma multi reporter which expects adaper array of each reporter to be initialized. Moving adaper array initialization before the isKarmaConfigAppropriate check in order to satisfy that contract.  re #254